### PR TITLE
fix: use catalog url

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ all: install-dependencies install check
 .PHONY: install-dependencies
 install-dependencies:
 	@echo "Installing monorepo dependencies..."
-	@yarn install --immutable
+	@npm_config_loglevel=error yarn install --immutable
 	@yarn workspaces foreach --all --interlaced run install --immutable
 	@echo "Successfully installed monorepo dependencies."
 

--- a/src/systems/dev/backstage/ourstage/app-config.yaml
+++ b/src/systems/dev/backstage/ourstage/app-config.yaml
@@ -79,8 +79,8 @@ catalog:
   # typically `packages/backend`.
   locations:
     # Ourchitecture entities catalog.
-    - type: file
-      target: ../../../catalog/catalog-info.yaml
+    - type: url
+      target: https://github.com/ourchitecture/monorepo/blob/main/src/systems/dev/backstage/catalog/catalog-info.yaml
 
     # Ourstage entities catalog.
     - type: file

--- a/src/systems/dev/backstage/ourstage/makefile
+++ b/src/systems/dev/backstage/ourstage/makefile
@@ -11,9 +11,8 @@ all: install-dependencies install check
 .PHONY: install-dependencies
 install-dependencies:
 	@echo "Installing ourstage dependencies..."
-	@yarn install \
-		--immutable \
-		--network-timeout 300000
+	@npm_config_loglevel=error yarn install --immutable
+	@yarn workspaces foreach --all --interlaced run install --immutable
 	@echo "Successfully installed ourstage dependencies."
 .PHONY: init
 init: install-dependencies


### PR DESCRIPTION
When built and running a docker container, Backstage cannot see other files in the monorepo.

Signed-off-by: OurchitectureIO <97544811+ourchitectureio@users.noreply.github.com>
